### PR TITLE
Synchronize web clipboard retrieval

### DIFF
--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -1003,7 +1003,7 @@ Vector<String> DisplayServerWeb::get_rendering_drivers_func() {
 
 // Clipboard
 void DisplayServerWeb::update_clipboard_callback(const char *p_text) {
-	String text = p_text;
+	String text = String::utf8(p_text);
 
 #ifdef PROXY_TO_PTHREAD_ENABLED
 	if (!Thread::is_main_thread()) {

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -1026,7 +1026,12 @@ void DisplayServerWeb::clipboard_set(const String &p_text) {
 }
 
 String DisplayServerWeb::clipboard_get() const {
-	godot_js_display_clipboard_get(update_clipboard_callback);
+	char *text_ptr = godot_js_display_clipboard_get();
+	if (text_ptr) {
+		String text = String::utf8(text_ptr);
+		godot_js_display_clipboard_free(text_ptr);
+		clipboard = text;
+	}
 	return clipboard;
 }
 

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -69,7 +69,7 @@ private:
 	Callable input_text_callback;
 	Callable drop_files_callback;
 
-	String clipboard;
+	mutable String clipboard;
 	Point2 touches[32];
 
 	Array voices;

--- a/platform/web/godot_js.h
+++ b/platform/web/godot_js.h
@@ -113,7 +113,8 @@ extern int godot_js_display_has_webgl(int p_version);
 
 // Display clipboard
 extern int godot_js_display_clipboard_set(const char *p_text);
-extern int godot_js_display_clipboard_get(void (*p_callback)(const char *p_text));
+extern char *godot_js_display_clipboard_get();
+extern void godot_js_display_clipboard_free(char *p_text);
 
 // Display cursor
 extern void godot_js_display_cursor_set_shape(const char *p_cursor);

--- a/platform/web/js/libs/library_godot_display.js
+++ b/platform/web/js/libs/library_godot_display.js
@@ -564,19 +564,28 @@ const GodotDisplay = {
 	},
 
 	godot_js_display_clipboard_get__proxy: 'sync',
-	godot_js_display_clipboard_get__sig: 'ii',
-	godot_js_display_clipboard_get: function (callback) {
-		const func = GodotRuntime.get_func(callback);
-		try {
+	godot_js_display_clipboard_get__sig: 'i',
+	godot_js_display_clipboard_get: function () {
+		if (!navigator.clipboard || typeof navigator.clipboard.readText !== 'function') {
+			return 0;
+		}
+		if (typeof Asyncify === 'undefined' || typeof Asyncify.handleSleep !== 'function') {
+			return 0;
+		}
+		return Asyncify.handleSleep(function (wakeUp) {
 			navigator.clipboard.readText().then(function (result) {
-				const ptr = GodotRuntime.allocString(result);
-				func(ptr);
-				GodotRuntime.free(ptr);
-			}).catch(function (e) {
-				// Fail graciously.
+				wakeUp(GodotRuntime.allocString(result));
+			}).catch(function () {
+				wakeUp(0);
 			});
-		} catch (e) {
-			// Fail graciously.
+		});
+	},
+
+	godot_js_display_clipboard_free__proxy: 'sync',
+	godot_js_display_clipboard_free__sig: 'vi',
+	godot_js_display_clipboard_free: function (p_ptr) {
+		if (p_ptr) {
+			GodotRuntime.free(p_ptr);
 		}
 	},
 


### PR DESCRIPTION
## Summary
- use Asyncify to synchronously fetch clipboard text from the browser runtime
- update the web display server to consume the returned buffer and refresh its cached clipboard state
- add a helper to release temporary clipboard buffers from JavaScript

## Testing
- not run (web export requires a browser environment not available in this container)


------
https://chatgpt.com/codex/tasks/task_e_68dee32ea0848322aeae5e5233b79ce2