### PR TITLE
Fix web clipboard paste to read synchronously

### DIFF
--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -1003,7 +1003,7 @@ Vector<String> DisplayServerWeb::get_rendering_drivers_func() {
 
 // Clipboard
 void DisplayServerWeb::update_clipboard_callback(const char *p_text) {
-	String text = p_text;
+	String text = String::utf8(p_text);
 
 #ifdef PROXY_TO_PTHREAD_ENABLED
 	if (!Thread::is_main_thread()) {

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -38,6 +38,8 @@
 #include "core/object/callable_method_pointer.h"
 #include "servers/rendering/dummy/rasterizer_dummy.h"
 
+#include <cstdlib>
+
 #ifdef GLES3_ENABLED
 #include "drivers/gles3/rasterizer_gles3.h"
 #endif
@@ -1026,8 +1028,14 @@ void DisplayServerWeb::clipboard_set(const String &p_text) {
 }
 
 String DisplayServerWeb::clipboard_get() const {
-	godot_js_display_clipboard_get(update_clipboard_callback);
-	return clipboard;
+        char *text = godot_js_display_clipboard_get();
+        if (text) {
+                String out = String::utf8(text);
+                free(text);
+                clipboard = out;
+                return out;
+        }
+        return clipboard;
 }
 
 void DisplayServerWeb::send_window_event_callback(int p_notification) {

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -69,7 +69,7 @@ private:
 	Callable input_text_callback;
 	Callable drop_files_callback;
 
-	String clipboard;
+        mutable String clipboard;
 	Point2 touches[32];
 
 	Array voices;

--- a/platform/web/godot_js.h
+++ b/platform/web/godot_js.h
@@ -113,7 +113,7 @@ extern int godot_js_display_has_webgl(int p_version);
 
 // Display clipboard
 extern int godot_js_display_clipboard_set(const char *p_text);
-extern int godot_js_display_clipboard_get(void (*p_callback)(const char *p_text));
+extern char *godot_js_display_clipboard_get();
 
 // Display cursor
 extern void godot_js_display_cursor_set_shape(const char *p_cursor);

--- a/platform/web/js/libs/library_godot_display.js
+++ b/platform/web/js/libs/library_godot_display.js
@@ -333,9 +333,10 @@ mergeInto(LibraryManager.library, GodotDisplayScreen);
  * Exposes all the functions needed by DisplayServer implementation.
  */
 const GodotDisplay = {
-	$GodotDisplay__deps: ['$GodotConfig', '$GodotRuntime', '$GodotDisplayCursor', '$GodotEventListeners', '$GodotDisplayScreen', '$GodotDisplayVK'],
-	$GodotDisplay: {
-		window_icon: '',
+        $GodotDisplay__deps: ['$GodotConfig', '$GodotRuntime', '$GodotDisplayCursor', '$GodotEventListeners', '$GodotDisplayScreen', '$GodotDisplayVK'],
+        $GodotDisplay: {
+                window_icon: '',
+                clipboard_ptr: 0,
 		getDPI: function () {
 			// devicePixelRatio is given in dppx
 			// https://drafts.csswg.org/css-values/#resolution
@@ -563,22 +564,32 @@ const GodotDisplay = {
 		return 0;
 	},
 
-	godot_js_display_clipboard_get__proxy: 'sync',
-	godot_js_display_clipboard_get__sig: 'ii',
-	godot_js_display_clipboard_get: function (callback) {
-		const func = GodotRuntime.get_func(callback);
-		try {
-			navigator.clipboard.readText().then(function (result) {
-				const ptr = GodotRuntime.allocString(result);
-				func(ptr);
-				GodotRuntime.free(ptr);
-			}).catch(function (e) {
-				// Fail graciously.
-			});
-		} catch (e) {
-			// Fail graciously.
-		}
-	},
+        godot_js_display_clipboard_get__proxy: 'async',
+        godot_js_display_clipboard_get__sig: 'i',
+        godot_js_display_clipboard_get: function () {
+                if (!navigator.clipboard || !navigator.clipboard.readText) {
+                        return 0;
+                }
+                return Asyncify.handleAsync(function () {
+                        return navigator.clipboard.readText().then(function (result) {
+                                if (GodotDisplay.clipboard_ptr) {
+                                        GodotRuntime.free(GodotDisplay.clipboard_ptr);
+                                        GodotDisplay.clipboard_ptr = 0;
+                                }
+                                if (typeof result !== 'string') {
+                                        result = '';
+                                }
+                                GodotDisplay.clipboard_ptr = GodotRuntime.allocString(result);
+                                return GodotDisplay.clipboard_ptr;
+                        }).catch(function () {
+                                if (GodotDisplay.clipboard_ptr) {
+                                        GodotRuntime.free(GodotDisplay.clipboard_ptr);
+                                        GodotDisplay.clipboard_ptr = 0;
+                                }
+                                return 0;
+                        });
+                });
+        },
 
 	/*
 	 * Window


### PR DESCRIPTION
## Summary
- make the web clipboard getter wait for `navigator.clipboard.readText()` and return the new string directly
- update the web display server to consume the returned buffer and keep its clipboard cache up to date
- allow the clipboard cache to be refreshed from const methods

## Testing
- scons platform=web tools=no target=template_release *(fails: Emscripten toolchain unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dee0e3c0f88322bf4272561beb8649